### PR TITLE
fix: eliminate render blocking resources

### DIFF
--- a/css/master.css
+++ b/css/master.css
@@ -4,7 +4,6 @@
   --sec-color: #331811;
   --sec-color-2: #61291c;
   --sec-text: #767e86;
-  --title-family: Playfair Display;
   --section-padding: 100px 0;
 }
 
@@ -65,10 +64,6 @@ img {
 
 .sec-text {
   color: var(--sec-text);
-}
-
-.tilte-family {
-  font-family: var(--title-family);
 }
 
 .h4 {

--- a/css/master.css
+++ b/css/master.css
@@ -196,6 +196,10 @@ body>.home .main-content {
   position: relative;
 }
 
+.home .text-container {
+  min-height: 239px;
+}
+
 body>.home .main-text {
   position: relative;
   /* z-index: 2; */
@@ -316,7 +320,7 @@ i.list {
 }
 
 .home .reserve {
-  min-height:295.5px;
+  min-height: 295.5px;
 }
 
 .home .reserve .box {
@@ -332,6 +336,25 @@ i.list {
 .home .reserve .box select {
   color: black;
   font-family: var(--title-family);
+  min-height: 41px;
+}
+
+.home .reserve .box .destination-select {
+  min-width: 104px;
+}
+
+.home .reserve .box .check-in-select {
+  min-width: 176px;
+}
+
+.home .reserve .box .check-out-select {
+  min-width: 174px;
+}
+
+.home .reserve .book {
+  min-height: 54px;
+  min-height: 54px;
+  height: 54px;
 }
 
 .home .reserve .book a {

--- a/css/master.css
+++ b/css/master.css
@@ -41,6 +41,12 @@ hr {
   width: 225px;
 }
 
+img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 .bg-main {
   background-color: var(--main-color);
 }
@@ -84,9 +90,7 @@ hr {
     font-size: 64px;
     font-family: var(--title-family);
     color: rgba(23, 36, 50, 1);
-
   }
-
 }
 
 @media (max-width:768px) {
@@ -95,9 +99,7 @@ hr {
     font-family: var(--title-family);
     color: rgba(23, 36, 50, 1);
     margin-bottom: 9px;
-
   }
-
 }
 
 @media (min-width:768px) {
@@ -105,12 +107,8 @@ hr {
     font-size: 40px;
     font-family: var(--title-family);
     color: rgba(23, 36, 50, 1);
-
   }
-
 }
-
-
 
 /* end component */
 .go-up {
@@ -120,7 +118,6 @@ hr {
   right: 20px;
   cursor: pointer;
   transition: 0.3s;
-
 }
 
 .go-up:hover {
@@ -142,7 +139,6 @@ body>.home {
   position: relative;
   height: 100vh;
   transition: 0.3s;
-
 }
 
 body>.home::after {
@@ -289,7 +285,6 @@ i.list {
   /* بننقلها جوّا الدروار */
   i.list {
     display: block;
-
   }
 
   body>.home .main-text h1 {
@@ -356,7 +351,6 @@ i.list {
   right: 15px;
   transform: translateY(-50%);
   z-index: 20;
-
 }
 
 .bullets ul li {
@@ -431,7 +425,6 @@ i.list {
 }
 
 .destination-gallery .slide-gallery .card::after {
-
   content: "";
   position: absolute;
   width: 100%;
@@ -441,7 +434,6 @@ i.list {
   left: 0;
   border-radius: 22px;
 }
-
 
 .destination-section .slide .card img,
 .offer-section .slide-offer .card img,
@@ -553,7 +545,6 @@ i.list {
 .blog .container .content .img {
   max-width: 100vw;
   width: 425px;
-
 }
 
 .blog .container .content img {
@@ -584,7 +575,6 @@ i.list {
   transform: translateY(-6px);
   right: -20px;
   z-index: -1;
-
 }
 
 .planners .container .text .link::before {
@@ -634,26 +624,20 @@ i.list {
   width: 190px;
   border-radius: 9px;
   transition: 0.3s;
-
 }
-
 
 .planners .container .imgs img:nth-of-type(2) {
   transform: translateY(-20px);
   box-shadow: 0px 0px 25px black;
 }
 
-
 .planners .container img:hover {
   transform: translateY(-20px);
   box-shadow: 0px 0px 25px black;
-
 }
-
 
 .planners .container .parent-img {
   transition: 0.3s;
-
 }
 
 .planners .container .parent-img.opacity-0 {
@@ -668,7 +652,6 @@ i.list {
   height: 140dvh;
   background-color: rgba(0, 0, 0, 0.3);
   z-index: 1;
-
 }
 
 .planners .container .parent-img .img-container {
@@ -709,7 +692,6 @@ i.list {
   bottom: 5px;
   display: flex;
   gap: 15px;
-
 }
 
 .planners .container .parent-img .img-container .slide-controler i {

--- a/css/master.css
+++ b/css/master.css
@@ -315,9 +315,9 @@ i.list {
   }
 }
 
-/* .home .reserve {
-    z-index: 2;
-} */
+.home .reserve {
+  min-height:295.5px;
+}
 
 .home .reserve .box {
   display: flex;

--- a/css/master.css
+++ b/css/master.css
@@ -1,19 +1,16 @@
-/* 
-start some compnents
-
-*/
 :root {
-    --main-color: #ff7757;
-    --main-color-2: #ffd2c7;
-    --sec-color: #331811;
-    --sec-color-2: #61291c;
-    --sec-text: #767e86;
-    --title-family:Playfair Display;
-    --section-padding:100px 0 ;
+  --main-color: #ff7757;
+  --main-color-2: #ffd2c7;
+  --sec-color: #331811;
+  --sec-color-2: #61291c;
+  --sec-text: #767e86;
+  --title-family: Playfair Display;
+  --section-padding: 100px 0;
 }
 
 html {
-  scroll-behavior: smooth; /* عشان الانتقال يبقى ناعم */
+  scroll-behavior: smooth;
+  /* عشان الانتقال يبقى ناعم */
 }
 
 /* تنسيقات الاسكرول */
@@ -22,255 +19,305 @@ html {
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--main-color-2); /* خلفية التراك */
+  background: var(--main-color-2);
+  /* خلفية التراك */
   border-radius: 10px;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--main-color); /* لون الاسكرول */
+  background: var(--main-color);
+  /* لون الاسكرول */
   border-radius: 10px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--sec-color-2); /* لون عند الهوفر */
+  background: var(--sec-color-2);
+  /* لون عند الهوفر */
 }
-hr{
-    height: 1px ;
-    background-color: var(--main-color);
-    width: 225px;
+
+hr {
+  height: 1px;
+  background-color: var(--main-color);
+  width: 225px;
 }
+
 .bg-main {
-    background-color: var(--main-color);
+  background-color: var(--main-color);
 }
 
 .bg-main-2 {
-    background-color: var(--main-color-2);
+  background-color: var(--main-color-2);
 }
 
 .bg-sec {
-    background-color: var(--sec-color);
+  background-color: var(--sec-color);
 }
 
 .bg-sec-2 {
-    background-color: var(--sec-color-2);
+  background-color: var(--sec-color-2);
 }
 
 .sec-text {
-    color: var(--sec-text);
+  color: var(--sec-text);
 }
 
-.tilte-family{
-    font-family: var(--title-family);
-}
-.h4{
-    color: var(--sec-text);
-    font-size: 18px;
+.tilte-family {
+  font-family: var(--title-family);
 }
 
-.section-padding{
-    padding: var(--section-padding);
+.h4 {
+  color: var(--sec-text);
+  font-size: 18px;
 }
+
+.section-padding {
+  padding: var(--section-padding);
+}
+
 .container {
-    margin-left: auto;
-    margin-right: auto;
+  margin-left: auto;
+  margin-right: auto;
 }
 
-@media (max-width:992px){
-.h1-title{
+@media (max-width:992px) {
+  .h1-title {
     font-size: 64px;
     font-family: var(--title-family);
     color: rgba(23, 36, 50, 1);
 
-}
+  }
 
 }
-@media (max-width:768px){
-.h1-title{
+
+@media (max-width:768px) {
+  .h1-title {
     font-size: 35px;
     font-family: var(--title-family);
     color: rgba(23, 36, 50, 1);
     margin-bottom: 9px;
 
-}
+  }
 
 }
-@media (min-width:768px){
-.h1-title{
+
+@media (min-width:768px) {
+  .h1-title {
     font-size: 40px;
     font-family: var(--title-family);
     color: rgba(23, 36, 50, 1);
 
-}
+  }
 
 }
 
 
 
 /* end component */
-.go-up{
-    position: fixed;
-    z-index: 10;
-    bottom: 20px;
-    right: 20px;
-    cursor: pointer;
-    transition: 0.3s;
-    
+.go-up {
+  position: fixed;
+  z-index: 10;
+  bottom: 20px;
+  right: 20px;
+  cursor: pointer;
+  transition: 0.3s;
+
 }
-.go-up:hover{
-    background-color: #e63e18;
+
+.go-up:hover {
+  background-color: #e63e18;
 }
-.go-up.opacity-0{
-    z-index: -100;
+
+.go-up.opacity-0 {
+  z-index: -100;
 }
+
 body {
-    font-family: "Rubik", sans-serif;
-    height: 4000px;
+  font-family: "Rubik", sans-serif;
+  height: 4000px;
 }
 
 body>.home {
-    background: url(../photos/background-0.webp) no-repeat fixed center;
-    background-size: cover;
-    position: relative;
-    height: 100vh;
-    transition: 0.3s;
-    
+  background: url(../photos/background-0.webp) no-repeat fixed center;
+  background-size: cover;
+  position: relative;
+  height: 100vh;
+  transition: 0.3s;
+
 }
 
 body>.home::after {
-    content: "";
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.3);
-    z-index: 0;
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 0;
 }
 
 body>.home .header {
-    z-index: 2;
-    position: relative;
-      /* عدّل عرض الدروار من هنا */
-    --drawer-width: 280px;
-    /* وعدّل الخلفية من هنا */
-    --drawer-bg: rgba(0,0,0,0.86);
+  z-index: 2;
+  position: relative;
+  /* عدّل عرض الدروار من هنا */
+  --drawer-width: 280px;
+  /* وعدّل الخلفية من هنا */
+  --drawer-bg: rgba(0, 0, 0, 0.86);
 }
 
 body>.home .links li {
-    overflow: hidden;
+  overflow: hidden;
 }
 
 body>.home .links a {
-    position: relative;
+  position: relative;
 }
 
 body>.home .links a::after,
 body>.home .links a::after {
-    content: "";
-    position: absolute;
-    left: 0;
-    bottom: -3px;
-    width: 100%;
-    height: 3px;
-    background-color: var(--main-color);
-    transition: 0.3s;
-    left: -100%;
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -3px;
+  width: 100%;
+  height: 3px;
+  background-color: var(--main-color);
+  transition: 0.3s;
+  left: -100%;
 }
 
 body>.home .links a:hover::after,
 body>.home .links a:active::after {
-    left: 0;
+  left: 0;
 }
 
 body>.home .main-content {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-evenly;
-    z-index: 1;
-    position: relative;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  z-index: 1;
+  position: relative;
 }
 
 body>.home .main-text {
-    position: relative;
-    /* z-index: 2; */
+  position: relative;
+  /* z-index: 2; */
 }
 
 body>.home .main-text h1 {
-    font-family: var(--title-family);
-    font-size: 84px;
-    line-height: normal;
-    max-width: 960px;
-    margin-top: 20px;
+  font-family: var(--title-family);
+  font-size: 84px;
+  line-height: normal;
+  max-width: 960px;
+  margin-top: 20px;
 }
-i.list {
-    display: none;
-}
-.parent-links{
-    position: fixed;
-    top: 0; right: calc(-1 * var(--drawer-width));  /* مقفول */
-    width: var(--drawer-width);
-    height: 100dvh;
-    background: var(--drawer-bg);
-    backdrop-filter: blur(2px);
-    padding: 16px;
-    display: flex; flex-direction: column; gap: 16px;
-    z-index: 1000;
-    transition: right .3s ease;           /* 0.3s زي ما طلبت */
-  }
-  .parent-links.show{ right: 0; }         /* فتح المنيو */
 
-  .parent-links .close{
-    align-self: flex-end;
-    font-size: 24px; cursor: pointer;
-  }
-  .parent-links .ul-links{
-    display: flex; flex-direction: column; gap: 12px;
-  }
-  .parent-links .account{
-    display: flex; flex-direction: column; gap: 12px;
-  }
+i.list {
+  display: none;
+}
+
+.parent-links {
+  position: fixed;
+  top: 0;
+  right: calc(-1 * var(--drawer-width));
+  /* مقفول */
+  width: var(--drawer-width);
+  height: 100dvh;
+  background: var(--drawer-bg);
+  backdrop-filter: blur(2px);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  z-index: 1000;
+  transition: right .3s ease;
+  /* 0.3s زي ما طلبت */
+}
+
+.parent-links.show {
+  right: 0;
+}
+
+/* فتح المنيو */
+
+.parent-links .close {
+  align-self: flex-end;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.parent-links .ul-links {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.parent-links .account {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 @media (max-width:1152px) {
-    body>.home .main-text h1{
+  body>.home .main-text h1 {
     font-size: 64px;
   }
 }
-  /* دِسكتوب */
-  @media (min-width: 769px){
-    .list{ display: none; }                /* أخفي زر الليست */
-    .ul-links{ display: flex; gap: 2rem; } /* شكل أفقي عادي */
+
+/* دِسكتوب */
+@media (min-width: 769px) {
+  .list {
+    display: none;
   }
-  /* موبايل */
-  @media (max-width: 768px){
-    .ul-links{ display: none; }/* بننقلها جوّا الدروار */
-    i.list {
+
+  /* أخفي زر الليست */
+  .ul-links {
+    display: flex;
+    gap: 2rem;
+  }
+
+  /* شكل أفقي عادي */
+}
+
+/* موبايل */
+@media (max-width: 768px) {
+  .ul-links {
+    display: none;
+  }
+
+  /* بننقلها جوّا الدروار */
+  i.list {
     display: block;
 
   }
-  body>.home .main-text h1{
+
+  body>.home .main-text h1 {
     font-size: 40px;
     border-bottom: 1px solid #ccc;
     padding-bottom: 10px;
   }
-  }
+}
 
 @media (max-width:320px) {
-    body>.home .main-text h1{
+  body>.home .main-text h1 {
     font-size: 40px;
   }
 }
 
-@media (max-width: 768px){
-    .destination-section .container,
-    .offer-section .container,
-    .destination-gallery .container{
-        flex-direction: column !important;
-    }
-        .destination-section .container div:nth-of-type(2),
-    .offer-section .container div:nth-of-type(2),
-    .destination-gallery .container div:nth-of-type(2){
-        margin: 20px auto 20px !important;
-    }
+@media (max-width: 768px) {
+
+  .destination-section .container,
+  .offer-section .container,
+  .destination-gallery .container {
+    flex-direction: column !important;
+  }
+
+  .destination-section .container div:nth-of-type(2),
+  .offer-section .container div:nth-of-type(2),
+  .destination-gallery .container div:nth-of-type(2) {
+    margin: 20px auto 20px !important;
+  }
 }
 
 /* .home .reserve {
@@ -278,61 +325,62 @@ i.list {
 } */
 
 .home .reserve .box {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .home .reserve .box span {
-    color: #767e86;
+  color: #767e86;
 }
 
 .home .reserve .box select {
-    color: black;
-    font-family: var(--title-family);
+  color: black;
+  font-family: var(--title-family);
 }
 
 .home .reserve .book a {
-    font-family: var(--title-family);
-    font-size: 20px;
+  font-family: var(--title-family);
+  font-size: 20px;
 }
 
 .bullets ul {
-    list-style: none;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    gap: 12px;
-    position: absolute;
-    top: 50%;
-    right: 15px;
-    transform: translateY(-50%);
-    z-index: 20;
-    
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  position: absolute;
+  top: 50%;
+  right: 15px;
+  transform: translateY(-50%);
+  z-index: 20;
+
 }
 
 .bullets ul li {
-    --value: 15px;
-    width: var(--value);
-    height: var(--value);
-    background-color: white;
-    transition: 0.3s;
-    border-radius: 50%;
-    cursor: pointer;
+  --value: 15px;
+  width: var(--value);
+  height: var(--value);
+  background-color: white;
+  transition: 0.3s;
+  border-radius: 50%;
+  cursor: pointer;
 }
 
 .bullets ul li.active,
 .bullets ul li:hover {
-    background-color: var(--main-color);
+  background-color: var(--main-color);
 }
+
 /* start destination And Offers */
 .destination-section .container,
 .offer-section .container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    overflow: hidden;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  overflow: hidden;
 }
 
 /* .destination-section .container .text h1,
@@ -344,28 +392,29 @@ i.list {
 
 .destination-section .container .text hr,
 .offer-section .container .text hr {
-    height: 1px;
-    width: 225px;
+  height: 1px;
+  width: 225px;
 }
 
 .destination-section .container .slide-control,
 .offer-section .container .slide-control {
-    align-self: flex-end;
+  align-self: flex-end;
 }
 
 .destination-section .container .slide-control button.minus-trans,
 .offer-section .container .slide-control button.minus-trans {
-    background-color: var(--main-color);
+  background-color: var(--main-color);
 }
 
 .destination-section .slide,
 .offer-section .slide-offer {
-    display: flex;
-    flex-wrap: nowrap;
-    align-items: center;
-    gap: 15px;
-    overflow: hidden;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 15px;
+  overflow: hidden;
 }
+
 .slide-offer {
   display: flex;
   gap: 15px;
@@ -376,276 +425,299 @@ i.list {
 .destination-section .slide .card,
 .offer-section .slide-offer .card,
 .destination-gallery .slide-gallery .card {
-    position: relative;
-    border-radius: 6px;
-    transition: 0.3s,transform 0.5s ease;
+  position: relative;
+  border-radius: 6px;
+  transition: 0.3s, transform 0.5s ease;
 }
-.destination-gallery .slide-gallery .card::after{
 
-    content: "";
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.3);
-    top: 0;
-    left: 0;
-    border-radius: 22px;
+.destination-gallery .slide-gallery .card::after {
+
+  content: "";
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+  top: 0;
+  left: 0;
+  border-radius: 22px;
 }
 
 
 .destination-section .slide .card img,
 .offer-section .slide-offer .card img,
 .destination-gallery .slide-gallery .card img {
-    width: 280px;
-    height: 335px;
-    max-width: initial;
-    border-radius: 20px;
-}
-.destination-gallery .slide-gallery .card *{
-    transition: 0.3s;
+  width: 280px;
+  height: 335px;
+  max-width: initial;
+  border-radius: 20px;
 }
 
-.destination-gallery .slide-gallery .card .link{
-    background-color: transparent;
-    position: absolute;
-    bottom: 0;
-    left: 20px;
-    color: white;
-    z-index: 1;
-    cursor: pointer;
+.destination-gallery .slide-gallery .card * {
+  transition: 0.3s;
 }
+
+.destination-gallery .slide-gallery .card .link {
+  background-color: transparent;
+  position: absolute;
+  bottom: 0;
+  left: 20px;
+  color: white;
+  z-index: 1;
+  cursor: pointer;
+}
+
 .destination-section .slide .card .info,
 .offer-section .slide-offer .card .info {
-    transition: 0.3s;
-    background-color: white;
-    position: absolute;
-    left: 0;
-    bottom: -100%;
-    width: 100%;
-    padding: 5px;
+  transition: 0.3s;
+  background-color: white;
+  position: absolute;
+  left: 0;
+  bottom: -100%;
+  width: 100%;
+  padding: 5px;
 }
 
 .destination-section .slide .card:hover .info,
 .offer-section .slide-offer .card:hover .info {
-    bottom: 0;
+  bottom: 0;
 }
 
 .destination-section .slide .card .info h2,
 .offer-section .slide-offer .card .info h2 {
-    font-family: var(--title-family);
-    margin-bottom: 15px;
-    font-weight: bold;
+  font-family: var(--title-family);
+  margin-bottom: 15px;
+  font-weight: bold;
 }
 
 .destination-section .slide .card .info p,
 .offer-section .slide-offer .card .info p {
-    color: var(--sec-text);
-    font-size: 16px;
-    line-height: 150%;
-    transform: translateX();
+  color: var(--sec-text);
+  font-size: 16px;
+  line-height: 150%;
+  transform: translateX();
 }
+
 .offer-section .slide-offer .card .info p {
-    line-height: normal;
+  line-height: normal;
 }
 
 /* .offer-section .slide-offer .card .info */
 .destination-section .slide .card .info a,
 .offer-section .slide-offer .card .info a {
-    background-color: var(--main-color);
-    padding: 8px 12px;
-    text-decoration: none;
-    color: white;
-    width: fit-content;
-    margin-left: auto;
-    margin-right: auto;
-    cursor: pointer;
-    margin-top: 5px;
-    display: block;
+  background-color: var(--main-color);
+  padding: 8px 12px;
+  text-decoration: none;
+  color: white;
+  width: fit-content;
+  margin-left: auto;
+  margin-right: auto;
+  cursor: pointer;
+  margin-top: 5px;
+  display: block;
 }
 
 .destination-section .slide .card .info a.book-now:hover,
 .offer-section .slide-offer .card .info a.book-now:hover {
-    background-color: var(--main-color-2);
+  background-color: var(--main-color-2);
 }
 
 /* start blog */
-.blog .container{
-    flex-direction: column;
-    gap: 100px;
+.blog .container {
+  flex-direction: column;
+  gap: 100px;
 }
-.blog .container .info p{
-    font-size: 18px;
-    line-height: 42px;
+
+.blog .container .info p {
+  font-size: 18px;
+  line-height: 42px;
 }
-@media (min-width:769px){
-.blog .container .content{
+
+@media (min-width:769px) {
+  .blog .container .content {
     display: flex;
     flex-direction: row;
     align-items: center;
     gap: 32px;
+  }
 }
-}
-@media (max-width:768px){
-    .blog .container .content{
+
+@media (max-width:768px) {
+  .blog .container .content {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 32px;
+  }
 }
-}
-.blog .container .content .img{
-    max-width: 100vw;
-    width: 425px;
+
+.blog .container .content .img {
+  max-width: 100vw;
+  width: 425px;
 
 }
-.blog .container .content img{
-    width: 425px;
-    border-radius: 25px;
-    max-width: 100vw;
+
+.blog .container .content img {
+  width: 425px;
+  border-radius: 25px;
+  max-width: 100vw;
 }
+
 /* start Planners */
-.planners.container text p{
-    font-size: 18px;
+.planners.container text p {
+  font-size: 18px;
 }
 
 .planners .container .text .link {
-    position: relative;
-    --value:43px;
-    width: fit-content;
-}
-.planners .container .text .link::after{
-    content: "";
-    position: absolute;
-    width: var(--value);
-    height: var(--value);
-    border-radius: 6px;
-    background-color: var(--sec-text);
-    top: 6px;
-    transform: translateY(-6px);
-    right: -20px;
-    z-index: -1;
-    
-}
-.planners .container .text .link::before{
-    content: "";
-    position: absolute;
-    width: var(--value);
-    height: var(--value);
-    border-radius: 6px;
-    background-color: #172432;
-    z-index: -1;
-    left: -21px;
-    top: -27px;
-}
-.planners .container .text .link a{
-    background-color: var(--main-color);
-    color: white;
-    padding: 9px 12px;
-    border-radius: 6px;
-}
-.planners .container .text .link a:hover{
-    background-color: #ff3c11;
+  position: relative;
+  --value: 43px;
+  width: fit-content;
 }
 
-@media (max-width:768px){
-.planners > .container{
+.planners .container .text .link::after {
+  content: "";
+  position: absolute;
+  width: var(--value);
+  height: var(--value);
+  border-radius: 6px;
+  background-color: var(--sec-text);
+  top: 6px;
+  transform: translateY(-6px);
+  right: -20px;
+  z-index: -1;
+
+}
+
+.planners .container .text .link::before {
+  content: "";
+  position: absolute;
+  width: var(--value);
+  height: var(--value);
+  border-radius: 6px;
+  background-color: #172432;
+  z-index: -1;
+  left: -21px;
+  top: -27px;
+}
+
+.planners .container .text .link a {
+  background-color: var(--main-color);
+  color: white;
+  padding: 9px 12px;
+  border-radius: 6px;
+}
+
+.planners .container .text .link a:hover {
+  background-color: #ff3c11;
+}
+
+@media (max-width:768px) {
+  .planners>.container {
     flex-direction: column;
+  }
 }
-}
+
 /* Start Planner */
-.planners .container .text p{
-    max-width: 520px;
-}
-.planners .container .imgs{
-        display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
-    justify-items: center;
-    width: 100%;
-    gap: 15px;
-}
-.planners .container .imgs img{
-    height: 230px;
-    width: 190px;
-    border-radius: 9px;
-    transition: 0.3s;
-
+.planners .container .text p {
+  max-width: 520px;
 }
 
+.planners .container .imgs {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  justify-items: center;
+  width: 100%;
+  gap: 15px;
+}
 
-.planners .container .imgs img:nth-of-type(2){
-        transform: translateY(-20px);
-    box-shadow: 0px 0px 25px black;
+.planners .container .imgs img {
+  height: 230px;
+  width: 190px;
+  border-radius: 9px;
+  transition: 0.3s;
+
 }
 
 
-.planners .container img:hover{
-    transform: translateY(-20px);
-    box-shadow: 0px 0px 25px black;
+.planners .container .imgs img:nth-of-type(2) {
+  transform: translateY(-20px);
+  box-shadow: 0px 0px 25px black;
+}
+
+
+.planners .container img:hover {
+  transform: translateY(-20px);
+  box-shadow: 0px 0px 25px black;
 
 }
 
 
 .planners .container .parent-img {
-    transition: 0.3s;
+  transition: 0.3s;
 
 }
-.planners .container .parent-img.opacity-0{
-    z-index: -100;
+
+.planners .container .parent-img.opacity-0 {
+  z-index: -100;
 }
+
 .planners .container .parent-img .over-lay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 140dvh;
-    background-color: rgba(0, 0, 0, 0.3);
-    z-index: 1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 140dvh;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 1;
 
 }
-.planners .container .parent-img .img-container{
+
+.planners .container .parent-img .img-container {
   background-color: white;
-    display: flex
-;
-    justify-content: flex-start;
-    align-items: center;
-    gap: 15px;
-    flex-wrap: nowrap;
-    width: 800px;
-    max-width: 100vw;
-    position: absolute;
-    top: 25%;
-    left: 50%;
-    transform: translate(-50%, 0%);
-    z-index: 2;
-    padding: 15px;
-    overflow: hidden;
-    height: 315px;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 15px;
+  flex-wrap: nowrap;
+  width: 800px;
+  max-width: 100vw;
+  position: absolute;
+  top: 25%;
+  left: 50%;
+  transform: translate(-50%, 0%);
+  z-index: 2;
+  padding: 15px;
+  overflow: hidden;
+  height: 315px;
 }
-.planners .container .parent-img .img-container img{
-    height: 230px;
-    width: 220px;
-    border-radius: 9px;
-    transition: all 0.3s;
-    max-width: initial;
+
+.planners .container .parent-img .img-container img {
+  height: 230px;
+  width: 220px;
+  border-radius: 9px;
+  transition: all 0.3s;
+  max-width: initial;
 }
-.planners .container .parent-img .img-container .card{
-    transition:all ease 0.5s;
+
+.planners .container .parent-img .img-container .card {
+  transition: all ease 0.5s;
 }
-.planners .container .parent-img .img-container .slide-controler{
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    bottom: 5px;
-    display: flex;
-    gap: 15px;
+
+.planners .container .parent-img .img-container .slide-controler {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 5px;
+  display: flex;
+  gap: 15px;
 
 }
-.planners .container .parent-img .img-container .slide-controler i{
-    background-color: var(--main-color);
-    padding: 9px 12px;
-    color: white;
-    cursor: pointer;
-    padding-right: 21px;
+
+.planners .container .parent-img .img-container .slide-controler i {
+  background-color: var(--main-color);
+  padding: 9px 12px;
+  color: white;
+  cursor: pointer;
+  padding-right: 21px;
 }
 
 /* start comments */
@@ -663,7 +735,7 @@ i.list {
   padding: 20px;
   border-radius: 12px;
   background: #fff;
-  box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
   transition: transform 0.5s ease;
   display: flex;
   flex-direction: column;
@@ -701,6 +773,7 @@ i.list {
   color: #777;
   margin-top: -8px;
 }
+
 /* footer */
 .footer {
   background-color: #172432;
@@ -721,12 +794,14 @@ i.list {
   margin-bottom: 30px;
 }
 
-.footer h2, .footer h3 {
+.footer h2,
+.footer h3 {
   margin-bottom: 15px;
   color: #fff;
 }
 
-.footer p, .footer a {
+.footer p,
+.footer a {
   color: #bbb;
   font-size: 14px;
   text-decoration: none;
@@ -760,11 +835,13 @@ i.list {
 .footer-bottom a:hover {
   color: #fff;
 }
+
 .footer-contact {
-  background: #f8f9fa; /* لون خلفية فاتح */
+  background: #f8f9fa;
+  /* لون خلفية فاتح */
   padding: 20px;
   border-radius: 12px;
-  box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
   max-width: 300px;
 }
 
@@ -786,12 +863,16 @@ i.list {
 }
 
 .footer-contact a:hover {
-  color: #006a6a; /* يتلون عند المرور */
-  transform: translateX(5px); /* حركة بسيطة */
+  color: #006a6a;
+  /* يتلون عند المرور */
+  transform: translateX(5px);
+  /* حركة بسيطة */
 }
 
 .footer-contact i {
   margin-right: 10px;
-  color: #006a6a; /* لون الأيقونات */
+  color: #006a6a;
+  /* لون الأيقونات */
 }
+
 /* end footer */

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
             <!-- End header -->
         </div>
         <div class="main-content">
-            <div class="container">
+            <div class="container text-container">
                 <div class="main-text text-white">
                     <h1 class="h1-title">Start your unforgettable journey with us.</h1>
                     <p class="mt-4 text-2xl">
@@ -91,7 +91,7 @@
                 <div class="planes flex flex-wrap md:flex-row flex-col gap-6 w-full">
                     <div class="box Destination flex flex-col w-full md:w-auto">
                         <span>Destination</span>
-                        <select class="border border-solid border-stone-500 p-2 rounded">
+                        <select class="destination-select border border-solid border-stone-500 p-2 rounded">
                             <!-- we will add it with js -->
                         </select>
                     </div>
@@ -105,13 +105,13 @@
                     </div>
                     <div class="box check-in flex flex-col w-full md:w-auto">
                         <span>Check in</span>
-                        <select class="border border-solid border-stone-500 p-2 rounded">
+                        <select class="check-in-select border border-solid border-stone-500 p-2 rounded">
                             <!-- I will add it with js -->
                         </select>
                     </div>
                     <div class="box check-out flex flex-col w-full md:w-auto">
                         <span>Check out</span>
-                        <select class="border border-solid border-stone-500 p-2 rounded">
+                        <select class="check-out-select border border-solid border-stone-500 p-2 rounded">
                             <!-- I will add it with js -->
                         </select>
                     </div>

--- a/index.html
+++ b/index.html
@@ -5,13 +5,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
-    <!-- css files -->
-    <link rel="stylesheet" href="css/brands.min.css" />
-    <link rel="stylesheet" href="css/all.min.css" />
-    <link rel="stylesheet" href="css/normalize.css" />
     <!-- tailwind -->
     <link rel="stylesheet" href="css/output.css" />
     <link rel="stylesheet" href="css/master.css" />
+    <!-- css files -->
+    <link rel="stylesheet" href="css/brands.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" href="css/all.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" href="css/normalize.css" media="print" onload="this.media='all'">
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -5,15 +5,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
-
-    <!-- google fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link
-        href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Rubik:ital,wght@0,300..900;1,300..900&display=swap"
-        rel="stylesheet">
-
-
     <!-- css files -->
     <link rel="stylesheet" href="css/brands.min.css" />
     <link rel="stylesheet" href="css/all.min.css" />


### PR DESCRIPTION
## Summary
This PR addresses **render-blocking resources** that can delay the page from displaying content quickly.  

### Changes
- **Removed unused font**: `Playfair Display` was not being used, so it was removed to reduce unnecessary font loading.
- **Deferred non-critical CSS**: Applied `media="print"` and `onload` attributes for non-critical styles to prevent them from blocking the initial render.

---

## Why this change is important
**Render-blocking resources** (fonts, CSS, and sometimes scripts) can prevent the browser from painting the page as soon as possible.  
This can lead to:

- **Slower First Contentful Paint (FCP)**: Users see a blank page longer.
- **Lower performance scores** in **Google Lighthouse** and **PageSpeed Insights**.
- **Poor user experience**: Visitors may leave if the page feels slow.

By removing unused fonts and deferring non-critical CSS:

- **Faster page rendering**: The browser can show visible content sooner.
- **Improved Core Web Vitals**: Better metrics like FCP and Largest Contentful Paint (LCP).
- **Reduced bandwidth usage**: Smaller resources to download.
- **Better SEO**: Google favors faster websites in search rankings.

---

## Testing
- Verified that removing the unused font does not break any visible text styling.
- Checked that deferred CSS still loads properly after the page is rendered.
- Measured **PageSpeed Insights** and **Lighthouse scores** to confirm improvements in render times.

---

## Notes & Tips
- Only load fonts that are actually used in your project.
- Defer or asynchronously load CSS that is not critical for above-the-fold content.
- This technique improves perceived performance and user experience, especially on slow connections.
- Regularly audit your CSS and fonts to eliminate unnecessary render-blocking resources.
