### PR TITLE
accessibility: fix aria attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -430,11 +430,11 @@
             <div class="footer-bottom">
                 <p>Follow me on:</p>
                 <a href="https://github.com/Ahmed-C0der" target="_blank">
-                    <i class="fa-brands fa-github"></i></i> GitHub
+                    <i class="fa-brands fa-github" aria-hidden="true"></i> GitHub
                 </a>
-                <a href="#"><i class="fa-brands fa-facebook"></i></a>
-                <a href="#"><i class="fa-brands fa-twitter"></i></a>
-                <a href="#"><i class="fa-brands fa-linkedin"></i></a>
+                <a href="#" aria-label="Facebook"><i class="fa-brands fa-facebook" aria-hidden="true"></i></a>
+                <a href="#" aria-label="Twitter"><i class="fa-brands fa-twitter" aria-hidden="true"></i></a>
+                <a href="#" aria-label="Linkedin"><i class="fa-brands fa-linkedin" aria-hidden="true"></i></a>
             </div>
         </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,10 @@
 
                 <div class="links">
                     <!-- زر فتح المنيو في الموبايل -->
-                    <i class="fa-solid fa-list list" style="cursor: pointer; font-size: 22px"></i>
+                    <button type="button" class="list" style="cursor: pointer; font-size: 22px"
+                        aria-label="Open mobile menu">
+                        <i class="fa-solid fa-list" aria-hidden="true"></i>
+                    </button>
 
                     <ul class="ul-links flex flex-row justify-between items-center gap-8">
                         <li><a href="#home">Home</a></li>

--- a/js/master.js
+++ b/js/master.js
@@ -17,7 +17,10 @@ function mountMobile() {
     if (drawer || window.innerWidth > 768) return;
     drawer = document.createElement('div');
     drawer.className = 'parent-links';
-    drawer.innerHTML = '<i class="fa-solid fa-xmark close" aria-label="Close"></i>';
+    drawer.innerHTML = `
+    <button type="button" class="close" aria-label="Close mobile menu">
+        <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+    </button>`
     header.appendChild(drawer);
 
     drawer.appendChild(ulLinks);


### PR DESCRIPTION
## Summary
This PR improves the accessibility of the mobile menu toggle buttons by:  
- Wrapping the icons inside `<button>` elements to make them accessible.  
- Adding **`aria-label`** attributes that describe the purpose of each button.  
- Hiding the decorative icons from screen readers using `aria-hidden="true"`.

---

## Why this change is important
Buttons that contain only icons or clickable elements like `<i>` are **not accessible** to users relying on screen readers.  

By providing **aria-labels**, hiding decorative icons, and using proper `<button>` elements:  
- Screen reader users can **understand and use** each button correctly.  
- Improves **WCAG compliance** and overall user experience.  
- Prevents confusion caused by clickable elements that are not semantic buttons.

**Tip:**  
When there is a **click event** on an element, make sure to either:  
1. Wrap it inside a `<button>`, or  
2. Use a `<button>` element directly,  
instead of adding click events to non-clickable elements like `<i>` or `<div>`.  
This ensures better accessibility and keyboard navigation support.